### PR TITLE
[AMB-129] Scripts to fix duplicate bug

### DIFF
--- a/marketdata/misc/AMB-129.cp.py
+++ b/marketdata/misc/AMB-129.cp.py
@@ -1,6 +1,7 @@
 import sys
 import glob
 
+# Update to "amberdata-marketdata"
 BUCKET = "amberdata-shar"
 
 def parse(suffix):
@@ -23,12 +24,8 @@ if __name__ == "__main__":
 
     DATA_DIR = sys.argv[1]
 
-    start = int(time.time())
-
     # sample file, DATA_DIR=/data4/shar/AMB-129/
     # /data4/shar/AMB-129/_pair=sol_usd/_date=2021-08-22/_hour=16/_exchange=kraken/part-00930-3273d399-96a3-457b-aed8-49a9ff5935de.c000.json
     file_paths = glob.glob(f"{DATA_DIR}/*/*/*/*/*")
 
     print_commands(DATA_DIR, file_paths)
-
-    end = int(time.time())

--- a/marketdata/misc/AMB-129.cp.py
+++ b/marketdata/misc/AMB-129.cp.py
@@ -2,7 +2,7 @@ import sys
 import glob
 
 # Update to "amberdata-marketdata"
-BUCKET = "amberdata-shar"
+BUCKET = "amberdata-marketdata"
 
 def parse(suffix):
     parts = suffix.split("/")
@@ -16,7 +16,7 @@ def print_commands(OUTPUT_DIR, file_paths):
     for file_path in file_paths:
         suffix = file_path.replace(f"{OUTPUT_DIR}/", "")
         (pair, dt, hr, exchange) = parse(suffix)
-        output_s3_file = f"s3://{BUCKET}/trade/{pair}/{dt}/{hr}/{exchange}-2022-02-10@00-00-00"
+        output_s3_file = f"s3://{BUCKET}/trade/{pair}/{dt}/{hr}/{exchange}-2022-02-16@06-30-00_1.0.0"
         cmd = f"aws s3 cp {file_path} {output_s3_file}"
         print(cmd)
 

--- a/marketdata/misc/AMB-129.cp.py
+++ b/marketdata/misc/AMB-129.cp.py
@@ -1,0 +1,34 @@
+import sys
+import glob
+
+BUCKET = "amberdata-shar"
+
+def parse(suffix):
+    parts = suffix.split("/")
+    pair = parts[0].split("=")[1]
+    dt = parts[1].split("=")[1]
+    hr = parts[2].split("=")[1]
+    exchange = parts[3].split("=")[1]
+    return (pair, dt, hr, exchange)
+
+def print_commands(OUTPUT_DIR, file_paths):
+    for file_path in file_paths:
+        suffix = file_path.replace(f"{OUTPUT_DIR}/", "")
+        (pair, dt, hr, exchange) = parse(suffix)
+        output_s3_file = f"s3://{BUCKET}/trade/{pair}/{dt}/{hr}/{exchange}-2022-02-10@00-00-00"
+        cmd = f"aws s3 cp {file_path} {output_s3_file}"
+        print(cmd)
+
+if __name__ == "__main__":
+
+    DATA_DIR = sys.argv[1]
+
+    start = int(time.time())
+
+    # sample file, DATA_DIR=/data4/shar/AMB-129/
+    # /data4/shar/AMB-129/_pair=sol_usd/_date=2021-08-22/_hour=16/_exchange=kraken/part-00930-3273d399-96a3-457b-aed8-49a9ff5935de.c000.json
+    file_paths = glob.glob(f"{DATA_DIR}/*/*/*/*/*")
+
+    print_commands(DATA_DIR, file_paths)
+
+    end = int(time.time())

--- a/marketdata/misc/AMB-129.mv.py
+++ b/marketdata/misc/AMB-129.mv.py
@@ -1,0 +1,35 @@
+import sys
+
+BUCKET = 'amberdata-shar'
+DIR = 'trade-old'
+
+def parse(path):
+    parts = path.split("/")
+    pair = parts[4]
+    dt = parts[5]
+    hr = parts[6]
+    file_name = parts[7]
+    return (pair, dt, hr, file_name)
+
+def print_commands(file_list_files):
+    with open(file_list_files, 'r') as f:
+        while True:
+            line = f.readline()
+            if not line:
+                break
+            line = line.strip()
+            (pair, dt, hr, file_name) = parse(line)
+            if not pair in ['ada_usd', 'btc_usd', 'eth_btc', 'eth_usd', 'eth_usdt', 'sol\_usd']:
+                break
+            if dt < '2021-06-01' or dt > '2021-02-08':
+                break
+
+            cmd = f"aws s3 mv {line} s3://{BUCKET}/{DIR}/{pair}/{dt}/{hr}/{file_name}"
+
+            print(cmd)
+            
+if __name__ == "__main__":
+
+    FILE_LIST_FILE = sys.argv[1]
+
+    print_commands(FILE_LIST_FILE)

--- a/marketdata/misc/AMB-129.mv.py
+++ b/marketdata/misc/AMB-129.mv.py
@@ -19,7 +19,7 @@ def print_commands(file_list_files):
                 break
             line = line.strip()
             (pair, dt, hr, file_name) = parse(line)
-            if not pair in ['ada_usd', 'btc_usd', 'eth_btc', 'eth_usd', 'eth_usdt', 'sol\_usd']:
+            if not pair in ['ada_usd', 'btc_usd', 'eth_btc', 'eth_usd', 'eth_usdt', 'sol_usd']:
                 break
             if dt < '2021-06-01' or dt > '2021-02-08':
                 break

--- a/marketdata/misc/AMB-129.sh
+++ b/marketdata/misc/AMB-129.sh
@@ -1,0 +1,26 @@
+
+#!/bin/bash
+
+####################################################################################
+
+# Copy corrected data on local machine. Do this once.
+#aws s3 sync "s3://amberdata-shar/AMB-129/" "/data4/shar/AMB-129/"
+
+python3 AMB-129.cp.py "/data4/shar/AMB-129" > cmd.cp.out
+
+parallel < cmd.cp.out
+
+aws s3 cp s3://amberdata-marketdata/trade/ . --recursive --dryrun > s3.out 2> s3.err
+time sed -e 's/.* \(s3.*\) to .*/\1/' s3.out > s3.out.files
+
+python3 AMB-129.cp.py s3.out.files > cmd.mv.out
+
+parallel < cmd.mv.out
+
+# cmd.cp.out, cmd.mv.out can be parsed to retrieve the new / old files names and add / delete these from
+# `trade_s3_objects`
+
+
+
+
+


### PR DESCRIPTION
Scripts used to fix data duplication bug.

- I already ran a Spark job see https://github.com/amberdata/spark-jobs/pull/2 which output deduped files to `s3://amberdata-shar/AMB-129`
- `AMB-129.cp.py` (`python3 AMB-129.cp.py "/data4/shar/AMB-129" > cmd.cp.out`) generates a command list to rename, copy generated deduped files to `s3://amberdata-marketdata/trade`. This can be run using `parallel`.
- `AMB-129.cp.py` (`python3 AMB-129.cp.py s3.out.files > cmd.mv.out`) generates a command list to move existing files with duplicates to temp dir.

Note: Already generated the entire file list for `s3://amberdata-marketdata/trade` at `10.30.50.178:/data4/shar/s3.out`. 